### PR TITLE
fix: update espa-surface-reflectance source to v3.5.2 for fill value fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN REPO_NAME=espa-product-formatter \
     && rm -rf ${REPO_NAME}
 RUN REPO_NAME=espa-surface-reflectance \
     && cd $SRC_DIR \
-    && git clone -b "fix/eros-collection2-3.5.1/masking-any-vs-all" https://github.com/NASA-IMPACT/${REPO_NAME}.git \
+    && git clone -b "eros-collection2-3.5.2" https://github.com/NASA-IMPACT/${REPO_NAME}.git \
     && cd ${REPO_NAME} \
     && make ENABLE_THREADING=yes \
     && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN REPO_NAME=espa-product-formatter \
     && rm -rf ${REPO_NAME}
 RUN REPO_NAME=espa-surface-reflectance \
     && cd $SRC_DIR \
-    && git clone -b "eros-collection2-3.5.1" https://github.com/NASA-IMPACT/${REPO_NAME}.git \
+    && git clone -b "fix/eros-collection2-3.5.1/masking-any-vs-all" https://github.com/NASA-IMPACT/${REPO_NAME}.git \
     && cd ${REPO_NAME} \
     && make ENABLE_THREADING=yes \
     && make install \


### PR DESCRIPTION
This PR updates our `hls-base` container to point to a bug fix update for LaSRC specific to the Sentinel-2 code path. This bug fix addresses incorrect pixel masking if "any" band has valid data rather than if "all" bands have valid data. This issue produces spurious and incorrect surface reflectance estimates along the edges of the granule.

This PR has some examples comparing the before/after, https://github.com/NASA-IMPACT/espa-surface-reflectance/pull/17

After merging this my plan was to create a new release tag for `hls-base@v3.5.2` so we can incorporate this into `hls-sentinel` (and `hls-landsat`, for consistency) containers.