### PR TITLE
fix: version tag for LaSRC we're using for our fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN REPO_NAME=espa-product-formatter \
     && rm -rf ${REPO_NAME}
 RUN REPO_NAME=espa-surface-reflectance \
     && cd $SRC_DIR \
-    && git clone -b "eros-collection2-3.5.2" https://github.com/NASA-IMPACT/${REPO_NAME}.git \
+    && git clone -b "v3.5.1.0" https://github.com/NASA-IMPACT/${REPO_NAME}.git \
     && cd ${REPO_NAME} \
     && make ENABLE_THREADING=yes \
     && make install \


### PR DESCRIPTION
We're going to append a "maintainer version" to the version we've forked LaSRC from instead of incrementing the patch version to reduce potential confusion. This PR changes the upstream tag to `v3.5.1.0`