### PR TITLE
fix: rebuilt version of Fmask 4_7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PREFIX=/usr/local \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PREFIX}/lib/python3.6/site-packages" \
     ESPA_SCHEMA="${PREFIX}/schema/espa_internal_metadata_v2_2.xsd" \
-    FMASK_VERSION="4_7"
+    FMASK_VERSION="4_7_issue40"
 
 RUN pip3 install scipy gsutil awscli gdal~=2.4
 

--- a/run_Fmask.sh
+++ b/run_Fmask.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-/usr/local/MATLAB/application/run_Fmask_4_7.sh /usr/local/MATLAB/R2022b /usr/local/MATLAB/application/AuxiData/ 
+/usr/local/MATLAB/application/run_Fmask_4_7.sh /usr/local/MATLAB/v912 /usr/local/MATLAB/application/AuxiData/
 


### PR DESCRIPTION
This PR updates our Fmask installation to use a re-release of v4.7 that corrects an issue with running Landsat Collection 2 data. This re-release is the same v4.7 that added support for Sentinel-2, but uses a different version of the Matlab Computed Runtime.

See, https://github.com/GERSL/Fmask/issues/40